### PR TITLE
[sigprocmask-fix] add posix import to fix unresolved sigprocmask when…

### DIFF
--- a/chronos/selectors2.nim
+++ b/chronos/selectors2.nim
@@ -33,6 +33,10 @@
 
 import stew/results
 import osdefs, osutils, oserrno
+
+when defined(linux) or defined(posix):
+  import posix
+
 export results, oserrno
 
 const


### PR DESCRIPTION
Fixes `/home/user/.nimble/pkgs/chronos-3.1.0/chronos/selectors2.nim(298, 12) Error: undeclared identifier: 'sigprocmask'` when building on linux/posix systems without enabling threading.